### PR TITLE
Fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,11 +152,11 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-[contributors]: https://github.com/frenck/python-wled/graphs/contributors
+[contributors]: https://github.com/frenck/action-yamllint/graphs/contributors
 [frenck]: https://github.com/frenck
 [github-sponsors-shield]: https://frenck.dev/wp-content/uploads/2019/12/github_sponsor.png
 [github-sponsors]: https://github.com/sponsors/frenck
-[license-shield]: https://img.shields.io/github/license/frenck/python-wled.svg
+[license-shield]: https://img.shields.io/github/license/frenck/action-yamllint.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2021.svg
 [project-stage-shield]: https://img.shields.io/badge/project%20stage-production%20ready-brightgreen.svg
 [releases-shield]: https://img.shields.io/github/release/frenck/action-yamllint.svg


### PR DESCRIPTION
This PR addresses a couple of broken links I've left behind creating the README (which was originally a copy-paste from another README of one of my repositories).

Oops 😓 