### PR TITLE
Fix log output by using a proble matcher instead

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -14,5 +14,6 @@ RUN \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 COPY entrypoint.sh /entrypoint.sh
+COPY matcher.json /matcher.json
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 declare -a options
 
-# This is a GitHub Action... Act like it :)
-options+=(--format github)
+# Use standard formatting, the GitHub Action annotation is nice, but
+# hides information from the logs. This action uses standard output
+# with a problem matcher instead.
+options+=(--format standard)
+
+# Register problem matcher
+cp /matcher.json "${PWD}/matcher.json"
+echo "::add-matcher::matcher.json"
 
 # Custom path for yamllint configuration input
 if [[ -n "${INPUT_CONFIG}" ]]; then

--- a/src/matcher.json
+++ b/src/matcher.json
@@ -1,0 +1,22 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "yamllint",
+      "pattern": [
+        {
+          "regexp": "^(.*\\.ya?ml)$",
+          "file": 1
+        },
+        {
+          "regexp": "^\\s{2}(\\d+):(\\d+)\\s+(error|warning)\\s+(.*?)\\s+\\((.*)\\)$",
+          "line": 1,
+          "column": 2,
+          "severity": 3,
+          "message": 4,
+          "code": 5,
+          "loop": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
yamllint has built-in support for GitHub Actions annotation output, however, recently, it makes GitHub hide certain information from the log output.

This PR changes the behavior by forcing yamllint to output its standard format, while providing a problem matcher for GitHub Action to do its annotation.

fixes #19
