### PR TITLE
Do not quote path

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -29,4 +29,4 @@ fi
 yamllint --version
 
 # Lint!
-exec yamllint "${options[@]}" "${INPUT_PATH:-.}"
+exec yamllint "${options[@]}" ${INPUT_PATH:-.}


### PR DESCRIPTION
As per [official documentation](https://yamllint.readthedocs.io/en/stable/quickstart.html#running-yamllint) yamlint supports multiple paths. If we force the quotes here, it's not possible to pass multiple paths.